### PR TITLE
Marked non-mutating methods as only requiring &self instead of &mut self

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -34,7 +34,7 @@ impl Backend for YAML {
         self.write(secrets).context("writing database")
     }
 
-    fn load(&mut self, name: String) -> Result<Encrypted> {
+    fn load(&self, name: String) -> Result<Encrypted> {
         self.read().context("loading database")?.into_iter().find(|s| {
             s.name == name
         }).map(|s| Ok(s)).unwrap_or_else(|| Err(Error::msg("secret not found")))
@@ -47,12 +47,12 @@ impl Backend for YAML {
         self.write(secrets)
     }
 
-    fn list(&mut self) -> Result<Vec<Encrypted>> {
+    fn list(&self) -> Result<Vec<Encrypted>> {
         self.read()
     }
 }
 impl YAML {
-    fn read(&mut self) -> Result<Vec<Encrypted>> {
+    fn read(&self) -> Result<Vec<Encrypted>> {
         Ok(::serde_yaml::from_str(&match ::std::fs::read_to_string(&self.path) {
             Err(err) if err.kind() == ::std::io::ErrorKind::NotFound => Ok("[]".to_string()),
             Err(err) => Err(err),
@@ -99,7 +99,7 @@ impl Backend for Folder {
         Ok(secret_f.write_all(encrypted.secret.as_bytes())?)
     }
 
-    fn load(&mut self, name: String) -> Result<Encrypted> {
+    fn load(&self, name: String) -> Result<Encrypted> {
         let salt_path = self.salt_path(&name);
         let secret_path = self.secret_path(&name);
         Ok(Encrypted{
@@ -113,7 +113,7 @@ impl Backend for Folder {
         Ok(::std::fs::remove_dir_all(self.path.join(name))?)
     }
 
-    fn list(&mut self) -> Result<Vec<Encrypted>> {
+    fn list(&self) -> Result<Vec<Encrypted>> {
         ::std::fs::read_dir(&self.path).context(
             "listing secret files"
         )?.collect::<Result<Vec<_>, _>>()?.into_iter().filter_map(|dir| {

--- a/src/database.rs
+++ b/src/database.rs
@@ -46,7 +46,7 @@ impl Database {
     }
 
     /// Load the `name` secret.
-    pub fn load(&mut self, name: String) -> Result<Secret> {
+    pub fn load(&self, name: String) -> Result<Secret> {
         self.e
             .decrypt(self.b.load(name).context("looking up name")?)
             .context("decrypting secret")
@@ -58,7 +58,7 @@ impl Database {
     }
 
     /// List all secrets.
-    pub fn list(&mut self) -> Result<Vec<Secret>> {
+    pub fn list(&self) -> Result<Vec<Secret>> {
         self.b
             .list()
             .context("listing secrets")?
@@ -77,7 +77,7 @@ impl Database {
     ///
     /// [1]: https://crates.io/crates/tinytemplate
     /// [2]: https://docs.rs/tinytemplate/1.0.4/tinytemplate/syntax/index.html
-    pub fn template(&mut self, mut template: String) -> Result<String> {
+    pub fn template(&self, mut template: String) -> Result<String> {
         template = ::snailquote::unescape(&format!("\"{}\"", template))?;
 
         let mut tt = ::tinytemplate::TinyTemplate::new();
@@ -101,9 +101,9 @@ struct TemplateContext {
     map: ::std::collections::HashMap<String, String>,
 }
 
-impl ::std::convert::TryFrom<&mut Database> for TemplateContext {
+impl ::std::convert::TryFrom<&Database> for TemplateContext {
     type Error = Error;
-    fn try_from(db: &mut Database) -> Result<Self> {
+    fn try_from(db: &Database) -> Result<Self> {
         let secrets = db.list()?;
         Ok(Self {
             list: secrets.clone(),

--- a/src/encrypters.rs
+++ b/src/encrypters.rs
@@ -40,7 +40,7 @@ impl Ring {
 }
 
 impl Encrypter for Ring {
-    fn encrypt(&mut self, secret: Secret) -> Result<Encrypted> {
+    fn encrypt(&self, secret: Secret) -> Result<Encrypted> {
         assert_eq!(::ring::aead::AES_256_GCM.tag_len(), TAG_SIZE);
 
         let plaintext = ::ring::aead::Aad::empty();
@@ -81,7 +81,7 @@ impl Encrypter for Ring {
         })
     }
 
-    fn decrypt(&mut self, encrypted: Encrypted) -> Result<Secret> {
+    fn decrypt(&self, encrypted: Encrypted) -> Result<Secret> {
         let plaintext = ::ring::aead::Aad::empty();
         let mut ciphertext = ::base64::decode(&encrypted.secret).context("decoding ciphertext")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,9 @@ mod database;
 /// [2]: backends/struct.Folder.html
 pub trait Backend {
     fn store(&mut self, encrypted: Encrypted) -> Result<()>;
-    fn load(&mut self, name: String) -> Result<Encrypted>;
+    fn load(&self, name: String) -> Result<Encrypted>;
     fn remove(&mut self, name: String) -> Result<()>;
-    fn list(&mut self) -> Result<Vec<Encrypted>>;
+    fn list(&self) -> Result<Vec<Encrypted>>;
 }
 pub mod backends;
 
@@ -55,8 +55,8 @@ pub mod backends;
 ///
 /// [1]: encrypters/struct.Ring.html
 pub trait Encrypter {
-    fn encrypt(&mut self, secret: Secret) -> Result<Encrypted>;
-    fn decrypt(&mut self, encrypted: Encrypted) -> Result<Secret>;
+    fn encrypt(&self, secret: Secret) -> Result<Encrypted>;
+    fn decrypt(&self, encrypted: Encrypted) -> Result<Secret>;
 }
 pub mod encrypters;
 


### PR DESCRIPTION
All existing methods require mutability for all operations, even those where no mutation actually occurs - this causes problems for having an immutable view into your secrets, especially when you want lock-free access to your secrets manager under an immutable context. This PR marks all list and read operations as immutable, as no mutable operations occur within any of the defined functions.