### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2018"
 
 [dependencies]
 anyhow = "^1"
-base64 = "^0"
+base64 = "0.13"
 clap = { version = "^3", features = ["derive"] }
-clishe = "^0"
-paste = "^0"
-ring = "^0"
+clishe = "0.2"
+paste = "0.1"
+ring = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "^1"
-serde_yaml = "^0"
-snailquote = "^0"
+serde_yaml = "^0.9"
+snailquote = "^0.3"
 tinytemplate = "^1"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.